### PR TITLE
Integrate Maxwell with S3 to store payloads larger than 1MB for kinesis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
       <version>0.12.8</version>
     </dependency>
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+      <version>1.11.341</version>
+    </dependency>
+    <dependency>
       <groupId>mysql</groupId>
       <artifactId>mysql-connector-java</artifactId>
       <version>8.0.17</version>

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.11.68</version>
+      <version>1.11.680</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
-      <version>1.11.341</version>
+      <version>1.11.680</version>
     </dependency>
     <dependency>
       <groupId>mysql</groupId>

--- a/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellConfig.java
@@ -1,5 +1,6 @@
 package com.zendesk.maxwell;
 
+import com.amazonaws.regions.Regions;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.github.shyiko.mysql.binlog.network.SSLMode;
@@ -66,6 +67,9 @@ public class MaxwellConfig extends AbstractConfig {
 
 	public String kinesisStream;
 	public boolean kinesisMd5Keys;
+	public boolean kinesisS3Enable;
+	public String kinesisS3Bucket;
+	public Regions kinesisS3Region;
 
 	public String sqsQueueUri;
 
@@ -252,6 +256,9 @@ public class MaxwellConfig extends AbstractConfig {
 
 		parser.section( "kinesis" );
 		parser.accepts( "kinesis_stream", "kinesis stream name" ).withOptionalArg();
+		parser.accepts("kinesis_s3_enable", "Kinesis S3 Integration Enable").withOptionalArg();
+		parser.accepts("kinesis_s3_bucket", "Kinesis S3 Bucket Name").withOptionalArg();
+		parser.accepts("kinesis_s3_region", "Kinesis S3 Region").withOptionalArg();
 		parser.accepts( "sqs_queue_uri", "SQS Queue uri" ).withRequiredArg();
 		parser.separator();
 		parser.addToSection("producer_partition_by");
@@ -482,6 +489,9 @@ public class MaxwellConfig extends AbstractConfig {
 
 		this.kinesisStream  = fetchOption("kinesis_stream", options, properties, null);
 		this.kinesisMd5Keys = fetchBooleanOption("kinesis_md5_keys", options, properties, false);
+		this.kinesisS3Enable = fetchBooleanOption("kinesis_s3_enable", options, properties, false);
+		this.kinesisS3Bucket = fetchOption("kinesis_s3_bucket", options, properties, null);
+		this.kinesisS3Region = Regions.fromName(fetchOption("kinesis_s3_region", options, properties, "ap-south-1"));
 
 		this.sqsQueueUri = fetchOption("sqs_queue_uri", options, properties, null);
 

--- a/src/main/java/com/zendesk/maxwell/MaxwellContext.java
+++ b/src/main/java/com/zendesk/maxwell/MaxwellContext.java
@@ -327,7 +327,8 @@ public class MaxwellContext {
 				this.producer = new MaxwellKafkaProducer(this, this.config.getKafkaProperties(), this.config.kafkaTopic);
 				break;
 			case "kinesis":
-				this.producer = new MaxwellKinesisProducer(this, this.config.kinesisStream);
+				this.producer = new MaxwellKinesisProducer(this, this.config.kinesisStream,
+						this.config.kinesisS3Enable, this.config.kinesisS3Bucket, this.config.kinesisS3Region);
 				break;
 			case "sqs":
 				this.producer = new MaxwellSQSProducer(this, this.config.sqsQueueUri);

--- a/src/main/java/com/zendesk/maxwell/util/S3Util.java
+++ b/src/main/java/com/zendesk/maxwell/util/S3Util.java
@@ -1,0 +1,48 @@
+package com.zendesk.maxwell.util;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import org.apache.commons.io.IOUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URL;
+
+public class S3Util {
+	private  static final Logger logger = LoggerFactory.getLogger(S3Util.class);
+
+	private final AmazonS3 amazonS3;
+
+	public S3Util(final AmazonS3 amazonS3) {
+		this.amazonS3 = amazonS3;
+	}
+
+	public URL upload(final String bucketName, final String keyName, final String content) {
+		logger.debug("Uploading file {} to bucket {}", keyName, bucketName);
+
+		final ObjectMetadata objectMetadata = new ObjectMetadata();
+
+		try {
+			objectMetadata.setContentLength(content.getBytes("UTF-8").length);
+		} catch (final UnsupportedEncodingException e) {
+			logger.error("Unsupported encoding exception while uploading to s3!", e);
+			throw new RuntimeException(e);
+		}
+
+		PutObjectRequest putObjectRequest = new PutObjectRequest(
+				bucketName,
+				keyName,
+				IOUtils.toInputStream(content),
+				objectMetadata
+		);
+		amazonS3.putObject(putObjectRequest);
+
+		return getUrl(bucketName, keyName);
+	}
+
+	private URL getUrl(final String bucketName, final String keyName) {
+		return amazonS3.getUrl(bucketName, keyName);
+	}
+}

--- a/src/test/java/com/zendesk/maxwell/producer/MaxwellKinesisProducerTest.java
+++ b/src/test/java/com/zendesk/maxwell/producer/MaxwellKinesisProducerTest.java
@@ -27,7 +27,7 @@ public class MaxwellKinesisProducerTest {
 		when(context.getConfig()).thenReturn(config);
 		when(context.getMetrics()).thenReturn(new NoOpMetrics());
 		String kinesisStream = "test-stream";
-		MaxwellKinesisProducer producer = new MaxwellKinesisProducer(context, kinesisStream);
+		MaxwellKinesisProducer producer = new MaxwellKinesisProducer(context, kinesisStream, false, null, null);
 
 		RowMap rowMap = new RowMap("insert", "MyDatabase", "MyTable", TIMESTAMP_MILLISECONDS, new ArrayList<String>(), POSITION);
 		StringBuilder r = new StringBuilder();


### PR DESCRIPTION
Currently kinesis has limit of 1MB per payload. So any payload larger than 1MB gets rejected and hence it fails. This provides the capability to push those large payloads to S3 and just push the s3 link via the stream. 